### PR TITLE
fix: Bump vtk.js

### DIFF
--- a/packages/molecule-vtkjs/package.json
+++ b/packages/molecule-vtkjs/package.json
@@ -19,7 +19,7 @@
     "@openchemistry/utils": "^0.3.3",
     "lodash-es": "^4.17.10",
     "resize-observer-polyfill": "^1.5.0",
-    "vtk.js": "7.5.2"
+    "vtk.js": "^7.5.5"
   },
   "devDependencies": {
     "@openchemistry/types": "^0.6.1",

--- a/packages/molecule-vtkjs/src/components/molecule-vtkjs/molecule-vtkjs.tsx
+++ b/packages/molecule-vtkjs/src/components/molecule-vtkjs/molecule-vtkjs.tsx
@@ -9,7 +9,8 @@ import { composeDisplayOptions } from '@openchemistry/utils';
 import { color2rgb, rowMaj2colMaj3d } from '@openchemistry/utils';
 import { validateChemJson, isChemJson } from '@openchemistry/utils';
 
-import vtk from 'vtk.js';
+import 'vtk.js';
+declare var vtk: any;
 
 @Component({
   tag: 'oc-molecule-vtkjs',


### PR DESCRIPTION
vtk.js has changed what they export. They no longer export an object called vtk, instead it is assigned to the window. So we have to change our import and declare a variable vtk, that will be present at runtime. This is not ideal. This can be cleaned up when we can get rollup to pull in the parts of vtk we need.