### PR TITLE
Update GET /molecules API to match new structure

### DIFF
--- a/packages/redux/src/ducks/molecules.js
+++ b/packages/redux/src/ducks/molecules.js
@@ -46,7 +46,7 @@ const reducer = handleActions({
     }
   },
   RECEIVE_MOLECULES: (state, action) => {
-    const molecules = action.payload.molecules.results;
+    const molecules = action.payload.molecules
     let byId = {};
     byId = molecules.reduce((result, item) => {
       result[item._id] = item;

--- a/packages/redux/src/ducks/molecules.js
+++ b/packages/redux/src/ducks/molecules.js
@@ -46,7 +46,7 @@ const reducer = handleActions({
     }
   },
   RECEIVE_MOLECULES: (state, action) => {
-    const molecules = action.payload.molecules;
+    const molecules = action.payload.molecules.results;
     let byId = {};
     byId = molecules.reduce((result, item) => {
       result[item._id] = item;

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { has } from 'lodash-es'
 import { put, call, takeEvery, take, select } from 'redux-saga/effects'
 
 import { molecules } from '@openchemistry/redux';
@@ -29,7 +30,7 @@ function setPaginationDefaults(options)
 {
   const defaults = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
   for (const key in defaults) {
-    if (options[key] === undefined) {
+    if (!has(options, key)) {
       options[key] = defaults[key]
     }
   }

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -55,7 +55,7 @@ export function fetchMoleculeByIdFromGirder(id) {
 // Molecules
 
 export function* fetchMolecules(action) {
-  let options = action.payload
+  const options = action.payload
   try {
     yield put( molecules.requestMolecules() )
     const res = yield call(fetchMoleculesFromGirder, options)

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -55,7 +55,7 @@ export function fetchMoleculeByIdFromGirder(id) {
 // Molecules
 
 export function* fetchMolecules(action) {
-  var options = action.payload
+  let options = action.payload
   try {
     yield put( molecules.requestMolecules() )
     const res = yield call(fetchMoleculesFromGirder, options)

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -36,8 +36,10 @@ function setPaginationDefaults(options)
 }
 
 export function fetchMoleculesFromGirder(options={}) {
-  setPaginationDefaults(options)
-  const params = { params: options }
+  // Let's modify a clone of the options instead of the original options
+  const optionsClone = { ...options }
+  setPaginationDefaults(optionsClone)
+  const params = { params: optionsClone }
   return girderClient().get('molecules', params)
           .then(response => response.data )
 }

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -27,7 +27,7 @@ import jp from 'jsonpath';
 
 function setPaginationDefaults(options)
 {
-  const defaults = { limit: 25, offset: 0, sort: '_id', sortDir: -1 }
+  const defaults = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
   for (const key in defaults) {
     if (options[key] === undefined) {
       options[key] = defaults[key]

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -45,7 +45,8 @@ export function fetchMoleculeByIdFromGirder(id) {
 export function* fetchMolecules() {
   try {
     yield put( molecules.requestMolecules() )
-    const newMolecules = yield call(fetchMoleculesFromGirder)
+    const res = yield call(fetchMoleculesFromGirder)
+    const newMolecules = res.results
     yield put( molecules.receiveMolecules(newMolecules) )
   }
   catch(error) {

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -25,8 +25,20 @@ import jp from 'jsonpath';
 
 // var jp = require('jsonpath')
 
-export function fetchMoleculesFromGirder() {
-  return girderClient().get('molecules')
+function setPaginationDefaults(options)
+{
+  const defaults = { limit: 25, offset: 0, sort: '_id', sortDir: -1 }
+  for (const key in defaults) {
+    if (options[key] === undefined) {
+      options[key] = defaults[key]
+    }
+  }
+}
+
+export function fetchMoleculesFromGirder(options={}) {
+  setPaginationDefaults(options)
+  const params = { params: options }
+  return girderClient().get('molecules', params)
           .then(response => response.data )
 }
 
@@ -42,10 +54,11 @@ export function fetchMoleculeByIdFromGirder(id) {
 
 // Molecules
 
-export function* fetchMolecules() {
+export function* fetchMolecules(action) {
+  var options = action.payload
   try {
     yield put( molecules.requestMolecules() )
-    const res = yield call(fetchMoleculesFromGirder)
+    const res = yield call(fetchMoleculesFromGirder, options)
     const newMolecules = res.results
     yield put( molecules.receiveMolecules(newMolecules) )
   }


### PR DESCRIPTION
This needs to get the `results` array from the new dictionary
structure.

This is the only change I've found so far that needs updating.