### PR TITLE
Update `GET /calculations` API and add pagination

### DIFF
--- a/packages/sagas/src/calculations.js
+++ b/packages/sagas/src/calculations.js
@@ -7,8 +7,14 @@ import { selectors } from '@openchemistry/redux';
 
 import girderClient from '@openchemistry/girder-client';
 
-function fetchCalculations(moleculeId) {
-  return girderClient().get('calculations', {params: {moleculeId}})
+import { setPaginationDefaults } from './index'
+
+function fetchCalculations(options={}) {
+  // Let's modify a clone of the options instead of the original options
+  const optionsClone = { ...options };
+  setPaginationDefaults(optionsClone);
+  const params = { params: optionsClone };
+  return girderClient().get('calculations', params)
           .then(response => response.data )
 }
 
@@ -46,8 +52,8 @@ export function* watchLoadCalculationNotebooks() {
 
 function* loadCalculations(action) {
   try {
-    const { moleculeId } = action.payload || {};
-    const res = yield call(fetchCalculations, moleculeId);
+    const options = action.payload
+    const res = yield call(fetchCalculations, options);
     const calculations = res.results;
     yield put(calculationsRedux.receiveCalculations({calculations}));
   } catch(error) {

--- a/packages/sagas/src/calculations.js
+++ b/packages/sagas/src/calculations.js
@@ -47,7 +47,8 @@ export function* watchLoadCalculationNotebooks() {
 function* loadCalculations(action) {
   try {
     const { moleculeId } = action.payload || {};
-    const calculations = yield call(fetchCalculations, moleculeId);
+    const res = yield call(fetchCalculations, moleculeId);
+    const calculations = res.results;
     yield put(calculationsRedux.receiveCalculations({calculations}));
   } catch(error) {
     yield put(calculationsRedux.requestCalculations(error))

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -26,7 +26,7 @@ import jp from 'jsonpath';
 
 // var jp = require('jsonpath')
 
-function setPaginationDefaults(options)
+export function setPaginationDefaults(options)
 {
   const defaults = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
   for (const key in defaults) {


### PR DESCRIPTION
Update the `GET /calculations` API and add pagination to oc-web-components.

This PR goes along with [this one](https://github.com/OpenChemistry/mongochemserver/pull/127).