### PR TITLE
Make girder-ui compatible with material-ui v4

### DIFF
--- a/packages/girder-ui/package-lock.json
+++ b/packages/girder-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@openchemistry/girder-ui",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2721,11 +2721,6 @@
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
 			}
-		},
-		"redux-form-material-ui": {
-			"version": "5.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/redux-form-material-ui/-/redux-form-material-ui-5.0.0-beta.3.tgz",
-			"integrity": "sha512-YoUZi6VvqoGDYk00bObf/2laTKZ4ApE5Bd7gItkgDYKor84K/kbzVj255oYNf8rMCAzXjQDQ2RgX3PSyES4uvQ=="
 		},
 		"regenerate": {
 			"version": "1.4.0",

--- a/packages/girder-ui/package.json
+++ b/packages/girder-ui/package.json
@@ -21,8 +21,7 @@
   "homepage": "https://github.com/OpenChemistry/oc-web-components#readme",
   "dependencies": {
     "@openchemistry/girder-redux": "^0.0.22",
-    "lodash-es": "^4.17.11",
-    "redux-form-material-ui": "^5.0.0-beta.3"
+    "lodash-es": "^4.17.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/packages/girder-ui/src/auth/components/username-login/index.js
+++ b/packages/girder-ui/src/auth/components/username-login/index.js
@@ -7,7 +7,8 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogTitle
+  DialogTitle,
+  TextField
 } from '@material-ui/core';
 
 import red from '@material-ui/core/colors/red';
@@ -15,10 +16,23 @@ import red from '@material-ui/core/colors/red';
 import InputIcon from '@material-ui/icons/Input';
 import ClearIcon from '@material-ui/icons/Clear';
 
-import {
-  TextField
-} from 'redux-form-material-ui';
 import { Field } from 'redux-form'
+
+const renderTextField = ({
+  label,
+  input,
+  meta: { touched, invalid, error },
+  ...custom
+}) => (
+  <TextField
+    label={label}
+    placeholder={label}
+    error={touched && invalid}
+    helperText={touched && error}
+    {...input}
+    {...custom}
+  />
+)
 
 const red500 = red['500'];
 
@@ -59,7 +73,7 @@ class GirderLogin extends Component {
               <Field
                 fullWidth
                 name="username"
-                component={TextField}
+                component={renderTextField}
                 placeholder="Username"
                 label="Username"
               />
@@ -68,7 +82,7 @@ class GirderLogin extends Component {
               <Field
                 fullWidth
                 name="password"
-                component={TextField}
+                component={renderTextField}
                 placeholder="Password"
                 label="Password"
                 type="password"
@@ -79,7 +93,7 @@ class GirderLogin extends Component {
               <Field
                 fullWidth
                 name="mfa"
-                component={TextField}
+                component={renderTextField}
                 placeholder="Multi-factor (if enabled)"
                 label="Multi-factor (if enabled)"
                 type="password"


### PR DESCRIPTION
It looks like the package `redux-form-material-ui` is not compatible with material-ui v4.
`redux-form-material-ui` simply wraps the various material-ui form elements in a way that can be fed directly to a `redux-form` field. This package hasn't been updated in a year, and the version compatible with material-ui >= 1.0 has never made it out of beta. I'm actually surprised it worked as long as it did.

Anyway, the fix is easy, we can stop using `redux-form-material-ui` and instead implement the glue between `redux-form` and `material-ui` ourselves as documented here: https://redux-form.com/8.2.2/examples/material-ui/

Fixes https://github.com/OpenChemistry/stemclient/issues/18

