### PR TITLE
Add a creatorId to molecule and calculation sagas

### DIFF
--- a/packages/sagas/src/calculations.js
+++ b/packages/sagas/src/calculations.js
@@ -16,7 +16,12 @@ function fetchCalculations(options={}, creatorId) {
   // Let's modify a clone of the options instead of the original options
   const optionsClone = { ...options };
   setPaginationDefaults(optionsClone);
-  const params = { params: {...optionsClone, creatorId} };
+
+  var params = { params: optionsClone };
+  if (creatorId) {
+    params = {params: {...optionsClone, creatorId}};
+  }
+
   return girderClient().get('calculations', params)
           .then(response => response.data )
 }

--- a/packages/sagas/src/calculations.js
+++ b/packages/sagas/src/calculations.js
@@ -18,7 +18,7 @@ function fetchCalculations(options={}, creatorId) {
   setPaginationDefaults(optionsClone);
 
   var params = { params: optionsClone };
-  if (creatorId) {
+  if (!isNil(creatorId)) {
     params = {params: {...optionsClone, creatorId}};
   }
 

--- a/packages/sagas/src/calculations.js
+++ b/packages/sagas/src/calculations.js
@@ -12,11 +12,11 @@ import girderClient from '@openchemistry/girder-client';
 
 import { setPaginationDefaults } from './index'
 
-function fetchCalculations(options={}) {
+function fetchCalculations(options={}, creatorId) {
   // Let's modify a clone of the options instead of the original options
   const optionsClone = { ...options };
   setPaginationDefaults(optionsClone);
-  const params = { params: optionsClone };
+  const params = { params: {...optionsClone, creatorId} };
   return girderClient().get('calculations', params)
           .then(response => response.data )
 }
@@ -55,8 +55,8 @@ export function* watchLoadCalculationNotebooks() {
 
 function* loadCalculations(action) {
   try {
-    const {options, loadMolecules} = action.payload
-    const res = yield call(fetchCalculations, options);
+    const {options, loadMolecules, creatorId} = action.payload
+    const res = yield call(fetchCalculations, options, creatorId);
     const calculations = res.results;
     const matches = res.matches;
     yield put(calculationsRedux.receiveCalculations({calculations, matches}));

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { has } from 'lodash-es'
+import { has, isNil } from 'lodash-es'
 import { put, call, takeEvery, take, select } from 'redux-saga/effects'
 
 import { molecules } from '@openchemistry/redux';
@@ -42,7 +42,7 @@ export function fetchMoleculesFromGirder(options={}, creatorId) {
   setPaginationDefaults(optionsClone)
 
   var params = { params: optionsClone }
-  if (creatorId){
+  if (!isNil(creatorId)){
     params = { params: {...optionsClone, creatorId} }
   }
 
@@ -63,7 +63,6 @@ export function fetchMoleculeByIdFromGirder(id) {
 // Molecules
 
 export function* fetchMolecules(action) {
-  console.log(action);
   const { options, creatorId } = action.payload
   try {
     yield put( molecules.requestMolecules() )

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -36,11 +36,11 @@ export function setPaginationDefaults(options)
   }
 }
 
-export function fetchMoleculesFromGirder(options={}) {
+export function fetchMoleculesFromGirder(options={}, creatorId) {
   // Let's modify a clone of the options instead of the original options
   const optionsClone = { ...options }
   setPaginationDefaults(optionsClone)
-  const params = { params: optionsClone }
+  const params = { params: {...optionsClone, creatorId} }
   return girderClient().get('molecules', params)
           .then(response => response.data )
 }
@@ -58,10 +58,11 @@ export function fetchMoleculeByIdFromGirder(id) {
 // Molecules
 
 export function* fetchMolecules(action) {
-  const options = action.payload
+  console.log(action);
+  const { options, creatorId } = action.payload
   try {
     yield put( molecules.requestMolecules() )
-    const res = yield call(fetchMoleculesFromGirder, options)
+    const res = yield call(fetchMoleculesFromGirder, options, creatorId)
     const newMolecules = res.results;
     const matches = res.matches;
     yield put( molecules.receiveMolecules(newMolecules, matches) )

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -40,7 +40,12 @@ export function fetchMoleculesFromGirder(options={}, creatorId) {
   // Let's modify a clone of the options instead of the original options
   const optionsClone = { ...options }
   setPaginationDefaults(optionsClone)
-  const params = { params: {...optionsClone, creatorId} }
+
+  var params = { params: optionsClone }
+  if (creatorId){
+    params = { params: {...optionsClone, creatorId} }
+  }
+
   return girderClient().get('molecules', params)
           .then(response => response.data )
 }


### PR DESCRIPTION
Pass in a creatorId parameter for fetchMoleculesFromGirder and
fetchCalculationsFromGirder to allow filtering calculations and molecules by user
id.

Signed-off-by: Brianna Major <brianna.major@kitware.com>